### PR TITLE
Added explicit import. ../goreq was breaking dep

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -16,7 +16,7 @@ import (
 	//	"encoding/json"
 	"strings"
 
-	"../goreq"
+	"github.com/smallnest/goreq"
 )
 
 func ExampleGoReq_SetClient() {


### PR DESCRIPTION
../goreq import in example_test.go seemed to keep dep from "init" or "ensure" so I made it an explicit import. 